### PR TITLE
Add Stop() for uber/fx hook

### DIFF
--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -3,7 +3,7 @@ package grpc
 import (
 	"net"
 
-	"github.com/asim/emque/proto"
+	mq "github.com/asim/emque/proto"
 	"github.com/asim/emque/server"
 	"github.com/asim/emque/server/util"
 	"google.golang.org/grpc"
@@ -12,6 +12,7 @@ import (
 
 type grpcServer struct {
 	options *server.Options
+	srv     *grpc.Server
 }
 
 func (g *grpcServer) Run() error {
@@ -50,12 +51,19 @@ func (g *grpcServer) Run() error {
 
 	// new grpc server
 	srv := grpc.NewServer(opts...)
+	g.srv = srv
 
 	// register MQ server
 	mq.RegisterMQServer(srv, new(handler))
 
 	// serve
 	return srv.Serve(l)
+}
+
+func (g *grpcServer) Stop() error {
+	g.srv.GracefulStop()
+	return nil
+
 }
 
 func New(opts ...server.Option) *grpcServer {

--- a/server/http/http.go
+++ b/server/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 type httpServer struct {
 	options *server.Options
+	srv     *http.Server
 }
 
 func (h *httpServer) Run() error {
@@ -58,7 +60,13 @@ func (h *httpServer) Run() error {
 		TLSConfig: config,
 	}
 
+	h.srv = srv
+
 	return srv.Serve(l)
+}
+
+func (h *httpServer) Stop() error {
+	return h.srv.Shutdown(context.TODO())
 }
 
 func New(opts ...server.Option) *httpServer {

--- a/server/server.go
+++ b/server/server.go
@@ -2,4 +2,5 @@ package server
 
 type Server interface {
 	Run() error
+	Stop() error
 }


### PR DESCRIPTION
I used emque as regular Go package in my project like this(project used uber/fx):

https://pkg.go.dev/go.uber.org/fx#StopHook

```go
func NewBroker(lc fx.Lifecycle, log *zap.Logger, conf *configv1.Config) *Broker {
	srvOptions := []server.Option{
		server.WithAddress(":8081"),
	}

	server := httpsrv.New(srvOptions...)

	lc.Append(fx.Hook{
		OnStart: func(ctx context.Context) error {
			log.Sugar().Infof("Starting Broker server at %v", 8081)
			go func() {
				if err := server.Run(); err != nil {
					log.Sugar().Errorf("Broker server err: %v", err)
				}
			}()
			return nil
		},
		OnStop: func(ctx context.Context) error {
			log.Sugar().Infof("Stopping Broker server")
			return server.Stop()
		},
	})

	return &Broker{}
}
```

So i add `Stop()` to `Server`

```go
type Server interface {
	Run() error
	Stop() error
}
```


